### PR TITLE
add .net 9 version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v2
     - name: Install dependencies

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 9.0.x
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v2
     - name: Install dependencies

--- a/AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csproj
+++ b/AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -15,12 +15,12 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.1.4" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.1.4" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.1.4" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.1.4" />
+    <PackageReference Include="Avalonia" Version="11.2.1" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.2.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.1" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.1" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.1.4" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.1" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
   </ItemGroup>
 

--- a/AstronomyPictureOfTheDay.Xunit.Tests/AstronomyPictureOfTheDay.Xunit.Tests.csproj
+++ b/AstronomyPictureOfTheDay.Xunit.Tests/AstronomyPictureOfTheDay.Xunit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj
+++ b/AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<PackageId>AstronomyPictureTheDay</PackageId>
 		<PackageVersion></PackageVersion>


### PR DESCRIPTION
This pull request includes several updates to upgrade the .NET version and update package references across multiple project files. The most important changes include updating the .NET version from 8.0 to 9.0 and upgrading the Avalonia package versions.

.NET Version Upgrades:

* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L69-R69): Updated the `dotnet-version` from 8.0.x to 9.0.x.
* [`.github/workflows/dotnet-core.yml`](diffhunk://#diff-36e3d7c516276ebd3d4a49df57499209ee1293dccca37fce615a1a69dcf716c0L27-R27): Updated the `dotnet-version` from 8.0.x to 9.0.x.
* [`AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csproj`](diffhunk://#diff-114f598c72e031b9482c92b73fe66be79f8bc5e460e28f11a4af045a744324e6L4-R4): Changed the `TargetFramework` from `net8.0` to `net9.0`.
* [`AstronomyPictureOfTheDay.Xunit.Tests/AstronomyPictureOfTheDay.Xunit.Tests.csproj`](diffhunk://#diff-2e149709c44e355f51cb606b8318949594ed922eabfefb5b3652c54119643a62L4-R4): Changed the `TargetFramework` from `net8.0` to `net9.0`.
* [`AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj`](diffhunk://#diff-d3853b767883823d395fd07269a4848f0fd3f7efbf0ad9795a441ed66ff41599L4-R4): Added `net9.0` to the `TargetFrameworks` list.

Package Reference Upgrades:

* [`AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csproj`](diffhunk://#diff-114f598c72e031b9482c92b73fe66be79f8bc5e460e28f11a4af045a744324e6L18-R23): Updated Avalonia package references from version 11.1.4 to 11.2.1.Please include in the comments what you are changing
