### PR TITLE
Update NuGet upload path in GitHub Actions

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -7,6 +7,7 @@ on:
     branches: [ main ]
 env:
   nuget_folder: "\\packages"
+  nuget_upload: "packages\*.nuget"
   upload_folder: "AstronomyPictureOfTheDay\\bin\\Release"
   solution: "AstronomyPictureOfTheDay.sln"
 jobs:
@@ -38,7 +39,7 @@ jobs:
       run: dotnet pack AstronomyPictureOfTheDay\AstronomyPictureOfTheDay.csproj --output ${{env.nuget_folder}} --configuration release /p:Version=2.0.${{ github.run_attempt }}
       
     - name: publish Nuget Packages to GitHub
-      run: dotnet nuget push ${{env.nuget_folder}}\*.nupkg --source ${{vars.NUGET_FEED}} --api-key ${{secrets.NUGET_PACKAGE_UPLOAD}} --skip-duplicate
+      run: dotnet nuget push ${{env.nuget_upload}} --source ${{vars.NUGET_FEED}} --api-key ${{secrets.NUGET_PACKAGE_UPLOAD}} --skip-duplicate
       if: github.event_name != 'pull_request'
       
     - name: Upload Artifact


### PR DESCRIPTION
Introduced a new environment variable `nuget_upload` in `dotnet-core.yml` to specify the path for NuGet packages. Updated the `publish Nuget Packages to GitHub` job to use this new variable, ensuring the correct files are pushed to the GitHub NuGet feed.


Closes #55 