### PR TITLE
Fix backslash escaping in dotnet-core.yml

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 env:
   nuget_folder: "\\packages"
-  nuget_upload: "packages\*.nuget"
+  nuget_upload: "packages\\*.nuget"
   upload_folder: "AstronomyPictureOfTheDay\\bin\\Release"
   solution: "AstronomyPictureOfTheDay.sln"
 jobs:


### PR DESCRIPTION
Updated the `nuget_upload` path in `dotnet-core.yml` to use double backslashes (`\\`) instead of a single backslash (`\`). This change ensures proper escaping of the backslash character in the file path.

Please include in the comments what you are changing
