### PR TITLE
Update dotnet-core.yml

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 env:
   nuget_folder: "\\packages"
-  nuget_upload: "\\packages\\*.nuget"
+  nuget_upload: "\\packages\\*.nupkg"
   upload_folder: "AstronomyPictureOfTheDay\\bin\\Release"
   solution: "AstronomyPictureOfTheDay.sln"
 jobs:


### PR DESCRIPTION
Fix file extension

This pull request includes a small but important change to the `.github/workflows/dotnet-core.yml` file. The change corrects the file extension for NuGet packages from `.nuget` to `.nupkg` to ensure proper handling and uploading of the packages.

* [`.github/workflows/dotnet-core.yml`](diffhunk://#diff-36e3d7c516276ebd3d4a49df57499209ee1293dccca37fce615a1a69dcf716c0L10-R10): Corrected the file extension for NuGet packages from `.nuget` to `.nupkg`.
