### PR TITLE
Update dotnet-core.yml

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -35,17 +35,13 @@ jobs:
     - name: Test
       run: dotnet test --configuration Release --no-build --verbosity normal
     - name: Generate build number
-      id: buildnumber
-      uses: einaregilsson/build-number@v2 
+      uses: onyxmueller/build-tag-number@v1
       with:
         token: ${{secrets.github_token}}        
-    - name: Upload build number
-      uses: actions/upload-artifact@v4
-      with:
-        name: BUILD_NUMBER
-        path: BUILD_NUMBER           
+    - name: Print new build number
+      run: echo "Build number is $BUILD_NUMBER"        
     - name: pack Nuget Packages
-      run: dotnet pack AstronomyPictureOfTheDay\AstronomyPictureOfTheDay.csproj --output ${{env.nuget_folder}} --configuration release /p:Version=2.0.${{steps.buildnumber.outputs.build_number}}
+      run: dotnet pack AstronomyPictureOfTheDay\AstronomyPictureOfTheDay.csproj --output ${{env.nuget_folder}} --configuration release /p:Version=2.0.${{BUILD_NUMBER}}
       
     - name: publish Nuget Packages to GitHub
       run: dotnet nuget push ${{env.nuget_upload}} --source ${{vars.NUGET_FEED}} --api-key ${{secrets.NUGET_PACKAGE_UPLOAD}} --skip-duplicate

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -35,13 +35,14 @@ jobs:
     - name: Test
       run: dotnet test --configuration Release --no-build --verbosity normal
     - name: Generate build number
+      id: buildnumber
       uses: onyxmueller/build-tag-number@v1
       with:
         token: ${{secrets.github_token}}        
     - name: Print new build number
-      run: echo "Build number is $BUILD_NUMBER"        
+      run: echo "Build number is ${env:BUILD_NUMBER}"        
     - name: pack Nuget Packages
-      run: dotnet pack AstronomyPictureOfTheDay\AstronomyPictureOfTheDay.csproj --output ${{env.nuget_folder}} --configuration release /p:Version=2.0.${{BUILD_NUMBER}}
+      run: dotnet pack AstronomyPictureOfTheDay\AstronomyPictureOfTheDay.csproj --output ${{env.nuget_folder}} --configuration release /p:Version=2.0.${{steps.buildnumber.outputs.build_number}}
       
     - name: publish Nuget Packages to GitHub
       run: dotnet nuget push ${{env.nuget_upload}} --source ${{vars.NUGET_FEED}} --api-key ${{secrets.NUGET_PACKAGE_UPLOAD}} --skip-duplicate

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -33,9 +33,7 @@ jobs:
     - name: Build
       run: msbuild ${{env.caliburn_sln}} /t:Build /p:Configuration=Release
     - name: Test
-      run: dotnet test --configuration Release --no-build --verbosity normal
-    - name: Print new build number
-      run: echo "Build number is ${{github:run_attempt}}"        
+      run: dotnet test --configuration Release --no-build --verbosity normal       
     - name: pack Nuget Packages
       run: dotnet pack AstronomyPictureOfTheDay\AstronomyPictureOfTheDay.csproj --output ${{env.nuget_folder}} --configuration release /p:Version=2.0.${{github.run_attempt}}
       

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -34,9 +34,18 @@ jobs:
       run: msbuild ${{env.caliburn_sln}} /t:Build /p:Configuration=Release
     - name: Test
       run: dotnet test --configuration Release --no-build --verbosity normal
-            
+    - name: Generate build number
+      id: buildnumber
+      uses: einaregilsson/build-number@v2 
+      with:
+        token: ${{secrets.github_token}}        
+    - name: Upload build number
+      uses: actions/upload-artifact@v1
+      with:
+        name: BUILD_NUMBER
+        path: BUILD_NUMBER           
     - name: pack Nuget Packages
-      run: dotnet pack AstronomyPictureOfTheDay\AstronomyPictureOfTheDay.csproj --output ${{env.nuget_folder}} --configuration release /p:Version=2.0.${{ github.run_attempt }}
+      run: dotnet pack AstronomyPictureOfTheDay\AstronomyPictureOfTheDay.csproj --output ${{env.nuget_folder}} --configuration release /p:Version=2.0.${{steps.buildnumber.outputs.build_number}}
       
     - name: publish Nuget Packages to GitHub
       run: dotnet nuget push ${{env.nuget_upload}} --source ${{vars.NUGET_FEED}} --api-key ${{secrets.NUGET_PACKAGE_UPLOAD}} --skip-duplicate

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -34,15 +34,10 @@ jobs:
       run: msbuild ${{env.caliburn_sln}} /t:Build /p:Configuration=Release
     - name: Test
       run: dotnet test --configuration Release --no-build --verbosity normal
-    - name: Generate build number
-      id: buildnumber
-      uses: onyxmueller/build-tag-number@v1
-      with:
-        token: ${{secrets.github_token}}        
     - name: Print new build number
-      run: echo "Build number is ${env:BUILD_NUMBER}"        
+      run: echo "Build number is ${github:run_attempt}"        
     - name: pack Nuget Packages
-      run: dotnet pack AstronomyPictureOfTheDay\AstronomyPictureOfTheDay.csproj --output ${{env.nuget_folder}} --configuration release /p:Version=2.0.${{steps.buildnumber.outputs.build_number}}
+      run: dotnet pack AstronomyPictureOfTheDay\AstronomyPictureOfTheDay.csproj --output ${{env.nuget_folder}} --configuration release /p:Version=2.0.${{github.run_attempt}}
       
     - name: publish Nuget Packages to GitHub
       run: dotnet nuget push ${{env.nuget_upload}} --source ${{vars.NUGET_FEED}} --api-key ${{secrets.NUGET_PACKAGE_UPLOAD}} --skip-duplicate

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Test
       run: dotnet test --configuration Release --no-build --verbosity normal
     - name: Print new build number
-      run: echo "Build number is ${github:run_attempt}"        
+      run: echo "Build number is ${{github:run_attempt}}"        
     - name: pack Nuget Packages
       run: dotnet pack AstronomyPictureOfTheDay\AstronomyPictureOfTheDay.csproj --output ${{env.nuget_folder}} --configuration release /p:Version=2.0.${{github.run_attempt}}
       

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         token: ${{secrets.github_token}}        
     - name: Upload build number
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: BUILD_NUMBER
         path: BUILD_NUMBER           


### PR DESCRIPTION
Change how getting build number for nuget packageThis pull request includes changes to the `.github/workflows/dotnet-core.yml` file to improve the build and release process by adding steps for generating and uploading a build number.

Enhancements to build and release process:

* Added a step to generate a build number using the `einaregilsson/build-number@v2` action.
* Added a step to upload the generated build number as an artifact using the `actions/upload-artifact@v1` action.
* Updated the `dotnet pack` command to use the generated build number in the package version.
