### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ on:
       - 'main'       # Run the workflow when pushing to the main branch
 
 env:
-  servicelocator_sln : "AstronomyPictureOfTheDay.sln"
+  nuget_project : "AstronomyPictureOfTheDay\AstronomyPictureOfTheDay.csproj"
   package_feed: "https://api.nuget.org/v3/index.json"
   nuget_folder: "\\packages"
   
@@ -26,11 +26,11 @@ jobs:
         with:
           dotnet-version: 9.0.x
       - name: Restore dependencies
-        run: dotnet restore ${{env.servicelocator_sln}}
+        run: dotnet restore ${{env.nuget_project}}
       - name: Build
-        run: dotnet build  ${{env.servicelocator_sln}} --no-restore --configuration Release 
+        run: dotnet build  ${{env.nuget_project}} --no-restore --configuration Release 
       - name: Pack Nuget
-        run: dotnet pack ${{env.servicelocator_sln}} --output ${{env.nuget_folder}}
+        run: dotnet pack ${{env.nuget_project}} --output ${{env.nuget_folder}}
       
       - name: publish Nuget Packages to GitHub
         run: dotnet nuget push packages/*.nupkg --source ${{env.package_feed}} --api-key ${{secrets.PUBLISH_TO_NUGET}} --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A standard library for calling the NASA Astronomy Picture Of The Day web service
 
 [![CodeQL](https://github.com/Ken-Tucker/AstronomyPictureOfTheDay/actions/workflows/codeql.yml/badge.svg)](https://github.com/Ken-Tucker/AstronomyPictureOfTheDay/actions/workflows/codeql.yml)
 
-![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/vb2ae/870c49615ed7c8b1af25a0f5f0d8f7a4/raw/nasa-
-[![CodeFactor](https://www.codefactor.io/repository/github/ken-tucker/AstronomyPictureOfTheDay/badge)](https://www.codefactor.io/repository/github/ken-tucker/AstronomyPictureOfTheDay)code-coverage.json)
+![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/vb2ae/870c49615ed7c8b1af25a0f5f0d8f7a4/raw/nasa-code-coverage.json)
+[![CodeFactor](https://www.codefactor.io/repository/github/ken-tucker/AstronomyPictureOfTheDay/badge)](https://www.codefactor.io/repository/github/ken-tucker/AstronomyPictureOfTheDay)
 
 #How to use the library
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A standard library for calling the NASA Astronomy Picture Of The Day web service
 ![badge](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/vb2ae/870c49615ed7c8b1af25a0f5f0d8f7a4/raw/nasa-code-coverage.json)
 [![CodeFactor](https://www.codefactor.io/repository/github/ken-tucker/AstronomyPictureOfTheDay/badge)](https://www.codefactor.io/repository/github/ken-tucker/AstronomyPictureOfTheDay)
 
-#How to use the library
+# How to use the library
 
 The library has 2 methods GetTodaysPictureAsync and GetMarsPictureAsync.  These methods allow you to get pictures from Nasa from one of the mars rovers or there astronomy picture of the day.
 


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/deploy.yml` file to streamline the deployment process by changing the environment variable and modifying the associated commands.

Key changes include:

* Updated the environment variable from `servicelocator_sln` to `nuget_project` to reference the specific project file instead of the solution file.
* Modified the `dotnet restore`, `dotnet build`, and `dotnet pack` commands to use the new `nuget_project` environment variable, ensuring they operate on the project file

Closes #56 