### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,6 @@ on:
       - 'main'       # Run the workflow when pushing to the main branch
 
 env:
-  nuget_project : "\\AstronomyPictureOfTheDay\\AstronomyPictureOfTheDay.csproj"
   package_feed: "https://api.nuget.org/v3/index.json"
   nuget_folder: "\\packages"
   
@@ -25,12 +24,10 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 9.0.x
-      - name: Restore dependencies
-        run: dotnet restore AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj
-      - name: Build
-        run: dotnet build  AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj --no-restore --configuration Release 
-      - name: Pack Nuget
-        run: dotnet pack AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj --output ${{env.nuget_folder}} --no-build
-      
+      - uses: actions/download-artifact@v4
+        name: "Download Node Modules - v4"
+        with:
+          name: published_nuget
+          path: ${{env.nuget_folder}}    
       - name: publish Nuget Packages to GitHub
         run: dotnet nuget push packages/*.nupkg --source ${{env.package_feed}} --api-key ${{secrets.PUBLISH_TO_NUGET}} --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ MINITES	Miniature Thermal Emission Spectrometer (Mini-TES)
 
 # Example app
 
-A WPF example is included in the source code
+An Avalonia UI example is included in the source code


### PR DESCRIPTION
This pull request includes updates to the deployment workflow and a minor documentation change. The most important changes are as follows:

Workflow updates:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L14): Removed the `nuget_project` environment variable and the steps for restoring dependencies, building, and packing the NuGet package. Added a step to download artifacts using `actions/download-artifact@v4` before publishing NuGet packages. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L14) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L28-R31)

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L56-R56): Updated the example application description from "A WPF example" to "An Avalonia UI example".