### PR TITLE
see if we can get nuget package from previous workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,23 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 9.0.x
-      - uses: actions/download-artifact@v4
+      - name: Get run ID of "Test" workflow
+        id: get-run-id
+        run: |
+            OTHER_REPO="${{ github.repository }}"
+            WF_NAME=[.NET Core]
+            RUN_ID=`gh run --repo ${OTHER_REPO} list --workflow ${WF_NAME} --json databaseId --jq .[0].databaseId`
+            echo "Detected latest run id of ${RUN_ID} for workflow ${WF_NAME}"
+            echo "run-id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+          env:
+            GH_TOKEN: ${{ github.token }}
+      - name: Download artifact from "Test" workflow
+        uses: actions/download-artifact@v4
+        with:
+            name: published_nuget # Match name used in dotnet-core.yml upload artifact step
+            github-token: ${{ github.token }}
+            repository: ${{ github.repository }}
+            run-id: ${{ steps.get-run-id.outputs.run-id }}
       - name: Display structure of downloaded files
         run: ls -R   
       


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/deploy.yml` file to improve the process of downloading artifacts from a previous workflow run. The most important changes include adding steps to retrieve the run ID of the "Test" workflow and using this ID to download the artifact.

Improvements to artifact download process:

* Added a step to retrieve the run ID of the "Test" workflow using the `gh run` command and set it as an output variable.
* Modified the artifact download step to use the retrieved run ID, ensuring that the correct artifact is downloaded from the "Test" workflow.
