### PR TITLE
fix typo in yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,12 +28,12 @@ jobs:
         id: get-run-id
         run: |
             OTHER_REPO="${{ github.repository }}"
-            WF_NAME=[.NET Core]
+            WF_NAME=".NET Core"
             RUN_ID=`gh run --repo ${OTHER_REPO} list --workflow ${WF_NAME} --json databaseId --jq .[0].databaseId`
             echo "Detected latest run id of ${RUN_ID} for workflow ${WF_NAME}"
             echo "run-id=${RUN_ID}" >> "$GITHUB_OUTPUT"
-          env:
-            GH_TOKEN: ${{ github.token }}
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Download artifact from "Test" workflow
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/deploy.yml` file. The change corrects the format of the `WF_NAME` variable to ensure proper execution of the GitHub Actions workflow.

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L31-R31): Changed `WF_NAME` assignment from `[.NET Core]` to `".NET Core"` to fix the workflow name format.