### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,5 +44,5 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R   
 
-      #- name: publish Nuget Packages to GitHub
-      #  run: dotnet nuget push packages/*.nupkg --source ${{env.package_feed}} --api-key ${{secrets.PUBLISH_TO_NUGET}} --skip-duplicate
+      - name: publish Nuget Packages to GitHub
+        run: dotnet nuget push *.nupkg --source ${{env.package_feed}} --api-key ${{secrets.PUBLISH_TO_NUGET}} --skip-duplicate


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/deploy.yml` file to re-enable the publishing of Nuget packages to GitHub. The commented-out section was uncommented and slightly modified.

Changes to deployment workflow:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L47-R48): Re-enabled the publishing of Nuget packages to GitHub by uncommenting and modifying the command to push all `.nupkg` files.
