### PR TITLE
fix readme not found

### DIFF
--- a/AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj
+++ b/AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj
@@ -19,7 +19,7 @@
 		<Copyright>2024</Copyright>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<Title>Astronomy Picture Of The Day</Title>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
+		<PackageReadmeFile>readme.md</PackageReadmeFile>
 	</PropertyGroup>
 	
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
This pull request includes a small change to the `AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj` file. The change corrects the casing of the `PackageReadmeFile` property to ensure it matches the actual file name.

* [`AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj`](diffhunk://#diff-d3853b767883823d395fd07269a4848f0fd3f7efbf0ad9795a441ed66ff41599L22-R22): Corrected the casing of `PackageReadmeFile` from `README.md` to `readme.md`.