### PR TITLE
Update NuGet packages for AstronomyPictureOfTheDay

### DIFF
--- a/AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csproj
+++ b/AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csproj
@@ -22,15 +22,15 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.2.5" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.3" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.3" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.2.5" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.5" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.5" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.5" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="HttpClientFactory" Version="1.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.2" />
     <PackageReference Include="System.Text.Json" Version="9.0.2" />
   </ItemGroup>
 

--- a/AstronomyPictureOfTheDay.Xunit.Tests/AstronomyPictureOfTheDay.Xunit.Tests.csproj
+++ b/AstronomyPictureOfTheDay.Xunit.Tests/AstronomyPictureOfTheDay.Xunit.Tests.csproj
@@ -17,13 +17,13 @@
     </PackageReference>
     <PackageReference Include="HttpClientFactory" Version="1.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.Json" Version="9.0.2" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj
+++ b/AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj
@@ -37,7 +37,7 @@
 	<ItemGroup>
 	  <PackageReference Include="HttpClientFactory" Version="1.0.5" />
 	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.2" />
-	  <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
+	  <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.2" />
 	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Upgraded `Avalonia` packages to version `11.2.5`,
`Microsoft.Extensions.Http` to `9.0.2`, and
`xunit.runner.visualstudio` to `3.0.2`.
These updates ensure the project utilizes the latest features and fixes.

Please include in the comments what you are changing.



[] Has unit tests for changed or new code

Closing #117 
