### PR TITLE
Get apod by date

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -40,20 +40,6 @@ jobs:
       run: msbuild ${{env.solution}} /t:Build /p:Configuration=Release
     - name: Test
       run: dotnet test --configuration Release -p:CollectCoverage=true -p:CoverletOutput=TestResults/ -p:CoverletOutputFormat=opencover --no-build --verbosity normal    
-    - name: Create Test Coverage Badge
-      uses: simon-k/dotnet-code-coverage-badge@v1.0.0
-      id: create_coverage_badge
-      with:
-        label: Unit Test Coverage
-        color: brightgreen
-        path: AstronomyPictureOfTheDay.Xunit.Tests/TestResults/coverage.opencover.xml
-        gist-filename: nasa-code-coverage.json
-        gist-id: 870c49615ed7c8b1af25a0f5f0d8f7a4
-        gist-auth-token: ${{ secrets.GIST_AUTH_TOKEN }}       
-    - name: Print code coverage
-      run: echo "Code coverage percentage ${{steps.create_coverage_badge.outputs.percentage}}%"
-    - name: Print badge data
-      run: echo "Badge data ${{steps.create_coverage_badge.outputs.badge}}"
 
        
     - name: pack Nuget Packages

--- a/AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csproj
+++ b/AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
@@ -21,12 +21,12 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.2.8" />
+    <PackageReference Include="Avalonia" Version="11.2.6" />
     <PackageReference Include="Avalonia.Desktop" Version="11.2.6" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.5" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.5" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.6" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.6" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.5" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.6" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="HttpClientFactory" Version="1.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />

--- a/AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csproj
+++ b/AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csproj
@@ -21,17 +21,17 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.2.6" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.2.6" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.6" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.6" />
+    <PackageReference Include="Avalonia" Version="11.3.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.0" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.0" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.2.6" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="HttpClientFactory" Version="1.0.5" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
-    <PackageReference Include="System.Text.Json" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
+    <PackageReference Include="System.Text.Json" Version="9.0.5" />
   </ItemGroup>
 
 

--- a/AstronomyPictureOfTheDay.Sample.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/AstronomyPictureOfTheDay.Sample.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -76,14 +76,13 @@ namespace AstronomyPictureOfTheDay.Sample.Avalonia.ViewModels
         public async Task<bool> GetPictureOfTheDay()
         {
             _dispatcherTimer.Stop();
-            bool result = false;
             PictureOfTheDayResponse response = await _apod.GetPictureByDateAsync(DateTime.Today, "DEMO_KEY");
+            bool result = response?.Success == true;
             if (response != null && response.Success)
             {
 
                 Title = response.pictureOfTheDay.title;
                 PictureOfDay = response.pictureOfTheDay.url;
-                result = true;
             }
             else
             {

--- a/AstronomyPictureOfTheDay.Sample.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/AstronomyPictureOfTheDay.Sample.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -77,7 +77,7 @@ namespace AstronomyPictureOfTheDay.Sample.Avalonia.ViewModels
         {
             _dispatcherTimer.Stop();
             bool result = false;
-            PictureOfTheDayResponse response = await _apod.GetTodaysPictureAsync("DEMO_KEY");
+            PictureOfTheDayResponse response = await _apod.GetPictureByDateAsync(DateTime.Today, "DEMO_KEY");
             if (response != null && response.Success)
             {
 

--- a/AstronomyPictureOfTheDay.Xunit.Tests/AstronomyPictureOfTheDay.Xunit.Tests.csproj
+++ b/AstronomyPictureOfTheDay.Xunit.Tests/AstronomyPictureOfTheDay.Xunit.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -7,14 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="HttpClientFactory" Version="1.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />

--- a/AstronomyPictureOfTheDay.Xunit.Tests/AstronomyPictureOfTheDay.Xunit.Tests.csproj
+++ b/AstronomyPictureOfTheDay.Xunit.Tests/AstronomyPictureOfTheDay.Xunit.Tests.csproj
@@ -8,18 +8,18 @@
 
   <ItemGroup>
     <PackageReference Include="HttpClientFactory" Version="1.0.5" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.Json" Version="9.0.4" />
+    <PackageReference Include="System.Text.Json" Version="9.0.5" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" Version="2.0.1" />
+    <PackageReference Include="xunit.v3" Version="2.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj
+++ b/AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj
@@ -36,12 +36,12 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Include="HttpClientFactory" Version="1.0.5" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.4" />
-	  <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.4" />
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
+	  <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
 	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Include="System.Text.Json" Version="9.0.4" />
+	  <PackageReference Include="System.Text.Json" Version="9.0.5" />
 	</ItemGroup>
 </Project>

--- a/AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj
+++ b/AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>

--- a/AstronomyPictureOfTheDay/INasaPictureOfTheDay.cs
+++ b/AstronomyPictureOfTheDay/INasaPictureOfTheDay.cs
@@ -8,5 +8,6 @@ namespace AstronomyPictureOfTheDay
     {
         Task<MarsPictureResponse> GetMarsPictureAsync(RoverEnum rover, DateTime earthDate, string apiKey);
         Task<PictureOfTheDayResponse> GetTodaysPictureAsync(string apiKey);
+        Task<PictureOfTheDayResponse> GetPictureByDateAsync(DateTime pictureDate, string apiKey);
     }
 }

--- a/AstronomyPictureOfTheDay/IRestServiceCaller.cs
+++ b/AstronomyPictureOfTheDay/IRestServiceCaller.cs
@@ -9,5 +9,6 @@ namespace AstronomyPictureOfTheDay
 
         Task<string> GetMarsPictureJsonAsync(string rover, DateTime earthDate, string apiKey);
 
+        Task<string> GetAPODByDateJsonAsync(DateTime pictureDate, string apiKey);
     }
 }

--- a/AstronomyPictureOfTheDay/NasaPictureOfTheDay.cs
+++ b/AstronomyPictureOfTheDay/NasaPictureOfTheDay.cs
@@ -83,5 +83,36 @@ namespace AstronomyPictureOfTheDay
 
             return response;
         }
+
+        public async Task<PictureOfTheDayResponse> GetPictureByDateAsync(DateTime pictureDate, string apiKey)
+        {
+            PictureOfTheDayResponse response = new PictureOfTheDayResponse();
+            try
+            {
+                string json = await restServiceCaller.GetAPODByDateJsonAsync(pictureDate, apiKey);
+
+                response.pictureOfTheDay = System.Text.Json.JsonSerializer.Deserialize<PictureOfTheDay>(json);
+                response.Success = true;
+            }
+            catch (HttpRequestException httpEx)
+            {
+                response.Success = false;
+                response.exception = httpEx;
+                response.CanRetry = true;
+            }
+            catch (TaskCanceledException taskCancelException)
+            {
+                response.Success = false;
+                response.exception = taskCancelException;
+                response.CanRetry = true;
+            }
+            catch (InvalidOperationException invalidOpException)
+            {
+                response.Success = false;
+                response.exception = invalidOpException;
+            }
+
+            return response;
+        }
     }
 }

--- a/AstronomyPictureOfTheDay/RestServiceCaller.cs
+++ b/AstronomyPictureOfTheDay/RestServiceCaller.cs
@@ -25,6 +25,13 @@ namespace AstronomyPictureOfTheDay
             return json;
         }
 
+        public async Task<string> GetAPODByDateJsonAsync(DateTime pictureDate, string apiKey)
+        {
+            string url = $"https://api.nasa.gov/planetary/apod?date={pictureDate:yyyy-MM-dd}&api_key={apiKey}";
+            string json = await client.GetStringAsync(url);
+            return json;
+        }
+
         public async Task<string> GetMarsPictureJsonAsync(string rover, DateTime earthDate, string apiKey)
         {
             string url = $"https://api.nasa.gov/mars-photos/api/v1/rovers/{rover}/photos?earth_date={earthDate:yyyy-MM-dd}&api_key={apiKey}";


### PR DESCRIPTION

This pull request introduces significant updates to the `AstronomyPictureOfTheDay` project, including enhancements to functionality, dependency updates, and new methods for fetching data. The most important changes include adding support for fetching NASA's Astronomy Picture of the Day (APOD) by a specific date, updating package dependencies across multiple projects, and removing outdated test-related packages.

### Functional Enhancements:

* Added a new method `GetPictureByDateAsync` to the `INasaPictureOfTheDay` interface for fetching APOD by a specific date. This method has been implemented in the `NasaPictureOfTheDay` class, enabling date-based API calls. (`[[1]](diffhunk://#diff-c39deec50bbefb2210309b110ef5dd72a948c6f7f000423344e30e8b09675b02R11)`, `[[2]](diffhunk://#diff-f88d4708e46906d7b061f2f657092e0a05c9289930b36cba396d3fec56a2a91cR84-R114)`)
* Introduced `GetAPODByDateJsonAsync` in the `IRestServiceCaller` interface and its implementation in `RestServiceCaller` to support the new date-based APOD functionality. (`[[1]](diffhunk://#diff-37dc9fea04b26115324a5b7045487b7485e0b398921b9aac80883015a69ffff3R12)`, `[[2]](diffhunk://#diff-ab8d7eba3fbffc19d02a60efba9044f6943d7de8f35d36125e8ba425a522a0ebR28-R34)`)
* Updated the `MainWindowViewModel` to use the new `GetPictureByDateAsync` method for fetching today's APOD, improving code clarity and flexibility. (`[AstronomyPictureOfTheDay.Sample.Avalonia/ViewModels/MainWindowViewModel.csL80-R80](diffhunk://#diff-d15746c8be7f43fd33da645be836dddd8ef5aa759040ee2cbdbb741ffe519cf0L80-R80)`)

### Dependency Updates:

* Updated Avalonia-related packages (`Avalonia`, `Avalonia.Desktop`, `Avalonia.Themes.Fluent`, `Avalonia.Fonts.Inter`) to version `11.3.0` in `AstronomyPictureOfTheDay.Sample.Avalonia.csproj`. (`[AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csprojL24-R34](diffhunk://#diff-114f598c72e031b9482c92b73fe66be79f8bc5e460e28f11a4af045a744324e6L24-R34)`)
* Updated several shared dependencies (`Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Http`, `System.Text.Json`) to version `9.0.5` across all project files. (`[[1]](diffhunk://#diff-114f598c72e031b9482c92b73fe66be79f8bc5e460e28f11a4af045a744324e6L24-R34)`, `[[2]](diffhunk://#diff-2e149709c44e355f51cb606b8318949594ed922eabfefb5b3652c54119643a62L10-R22)`, `[[3]](diffhunk://#diff-d3853b767883823d395fd07269a4848f0fd3f7efbf0ad9795a441ed66ff41599L39-R45)`)

### Test Project Cleanup:

* Removed outdated test-related packages (`coverlet.collector`, `coverlet.msbuild`) from `AstronomyPictureOfTheDay.Xunit.Tests.csproj`. (`[AstronomyPictureOfTheDay.Xunit.Tests/AstronomyPictureOfTheDay.Xunit.Tests.csprojL10-R22](diffhunk://#diff-2e149709c44e355f51cb606b8318949594ed922eabfefb5b3652c54119643a62L10-R22)`)
* Updated `Microsoft.NET.Test.Sdk` to version `17.14.0` and other testing-related packages (`xunit.runner.visualstudio`, `xunit.v3`) to their latest versions. (`[AstronomyPictureOfTheDay.Xunit.Tests/AstronomyPictureOfTheDay.Xunit.Tests.csprojL10-R22](diffhunk://#diff-2e149709c44e355f51cb606b8318949594ed922eabfefb5b3652c54119643a62L10-R22)`)

