### PR TITLE
Add Microsoft.Sboms.Targets

### DIFF
--- a/AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj
+++ b/AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj
@@ -43,5 +43,9 @@
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
 	  <PackageReference Include="System.Text.Json" Version="9.0.7" />
+	  <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.0">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+	  </PackageReference>
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Add Microsoft.Sboms.Targets

This pull request adds a new build dependency to the project, specifically for software bill of materials (SBOM) generation.

Dependency management:

* Added `Microsoft.Sbom.Targets` version 4.1.0 as a private build dependency in `AstronomyPictureOfTheDay.csproj` to enable SBOM generation and improve supply chain security.





