### PR TITLE
Update Avalonia package versions to 11.3.13

### DIFF
--- a/AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csproj
+++ b/AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csproj
@@ -21,12 +21,12 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.12" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.12" />
+    <PackageReference Include="Avalonia" Version="11.3.13" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.3.13" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.13" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.13" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.12" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.13" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="HttpClientFactory" Version="1.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />


### PR DESCRIPTION
This pull request updates the Avalonia-related dependencies in the `AstronomyPictureOfTheDay.Sample.Avalonia` project to the latest patch version. No other changes were made.

Dependency updates:

* Upgraded all Avalonia packages (`Avalonia`, `Avalonia.Desktop`, `Avalonia.Themes.Fluent`, `Avalonia.Fonts.Inter`, and `Avalonia.Diagnostics`) from version `11.3.12` to `11.3.13` in `AstronomyPictureOfTheDay.Sample.Avalonia.csproj`.Please include in the comments what you are changing.



[] Has unit tests for changed or new code

