### PR TITLE
Upgrade Avalonia to 12.0.0 and update test SDK

### DIFF
--- a/AstronomyPictureOfTheDay.Sample.Avalonia/App.axaml.cs
+++ b/AstronomyPictureOfTheDay.Sample.Avalonia/App.axaml.cs
@@ -28,7 +28,6 @@ namespace AstronomyPictureOfTheDay.Sample.Avalonia
                 var vm = services.GetRequiredService<MainWindowViewModel>();
                 // Line below is needed to remove Avalonia data validation.
                 // Without this line you will get duplicate validations from both Avalonia and CT
-                BindingPlugins.DataValidators.RemoveAt(0);
                 desktop.MainWindow = new MainWindow
                 {
                     DataContext = vm

--- a/AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csproj
+++ b/AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csproj
@@ -21,10 +21,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.13" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.13" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.13" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.13" />
+    <PackageReference Include="Avalonia" Version="12.0.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.0" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.0" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.0" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.13" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />

--- a/AstronomyPictureOfTheDay.Xunit.Tests/AstronomyPictureOfTheDay.Xunit.Tests.csproj
+++ b/AstronomyPictureOfTheDay.Xunit.Tests/AstronomyPictureOfTheDay.Xunit.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="HttpClientFactory" Version="1.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="System.Text.Json" Version="10.0.5" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />


### PR DESCRIPTION
Upgraded Avalonia packages to 12.0.0 and Microsoft.NET.Test.Sdk to 18.4.0. Removed first data validator in App.axaml.cs to change data validation behavior.



