### PR TITLE
Update nuget di 10 7

### DIFF
--- a/AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csproj
+++ b/AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csproj
@@ -29,10 +29,10 @@
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.14" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="HttpClientFactory" Version="1.0.5" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Text.Json" Version="10.0.5" />
+    <PackageReference Include="System.Text.Json" Version="10.0.7" />
   </ItemGroup>
 
 

--- a/AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csproj
+++ b/AstronomyPictureOfTheDay.Sample.Avalonia/AstronomyPictureOfTheDay.Sample.Avalonia.csproj
@@ -21,10 +21,10 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.1" />
+    <PackageReference Include="Avalonia" Version="12.0.2" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.2" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.2" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.2" />
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.14" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />

--- a/AstronomyPictureOfTheDay.Xunit.Tests/AstronomyPictureOfTheDay.Xunit.Tests.csproj
+++ b/AstronomyPictureOfTheDay.Xunit.Tests/AstronomyPictureOfTheDay.Xunit.Tests.csproj
@@ -8,11 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="HttpClientFactory" Version="1.0.5" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="System.Text.Json" Version="10.0.5" />
+    <PackageReference Include="System.Text.Json" Version="10.0.7" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/AstronomyPictureOfTheDay.Xunit.Tests/AstronomyPictureOfTheDay.Xunit.Tests.csproj
+++ b/AstronomyPictureOfTheDay.Xunit.Tests/AstronomyPictureOfTheDay.Xunit.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="HttpClientFactory" Version="1.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="System.Text.Json" Version="10.0.7" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />

--- a/AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj
+++ b/AstronomyPictureOfTheDay/AstronomyPictureOfTheDay.csproj
@@ -36,14 +36,14 @@
 	</ItemGroup>
 	<ItemGroup>
 	  <PackageReference Include="HttpClientFactory" Version="1.0.5" />
-	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-	  <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.5" />
-	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201">
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7" />
+	  <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
 	  <PackageReference Include="System.Net.Http" Version="4.3.4" />
-	  <PackageReference Include="System.Text.Json" Version="10.0.5" />
+	  <PackageReference Include="System.Text.Json" Version="10.0.7" />
 	  <PackageReference Include="Microsoft.Sbom.Targets" Version="4.1.5">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION

This pull request updates several NuGet package dependencies across the main project, the Avalonia sample, and the test project. These updates primarily bring the packages to their latest patch versions, ensuring improved compatibility, bug fixes, and security.

Dependency updates:

**Core library and dependency upgrades:**
* Updated `Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Http`, and `System.Text.Json` to version 10.0.7 in `AstronomyPictureOfTheDay`, `AstronomyPictureOfTheDay.Sample.Avalonia`, and `AstronomyPictureOfTheDay.Xunit.Tests` projects. [[1]](diffhunk://#diff-114f598c72e031b9482c92b73fe66be79f8bc5e460e28f11a4af045a744324e6L24-R35) [[2]](diffhunk://#diff-2e149709c44e355f51cb606b8318949594ed922eabfefb5b3652c54119643a62L11-R15) [[3]](diffhunk://#diff-d3853b767883823d395fd07269a4848f0fd3f7efbf0ad9795a441ed66ff41599L39-R46)
* Updated `Microsoft.SourceLink.GitHub` to version 10.0.203 in `AstronomyPictureOfTheDay`.

**UI and test framework packages:**
* Updated `Avalonia`, `Avalonia.Desktop`, `Avalonia.Themes.Fluent`, and `Avalonia.Fonts.Inter` to version 12.0.2 in the `AstronomyPictureOfTheDay.Sample.Avalonia` project.
* Updated `Microsoft.NET.Test.Sdk` to version 18.5.1 in the `AstronomyPictureOfTheDay.Xunit.Tests` project.

